### PR TITLE
Small updates to the AssetConverter

### DIFF
--- a/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Casc/CascListFile.cpp
+++ b/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Casc/CascListFile.cpp
@@ -95,7 +95,7 @@ void CascListFile::ParseListFile()
 		_fileIDToPath[fileID] = filePath;
 		_filePathToID[filePath] = fileID;
 
-		if (StringUtils::EndsWith(filePath, ".m2"))
+		if (StringUtils::EndsWith(filePath, ".m2") || StringUtils::EndsWith(filePath, ".mdx"))
 		{
 			_m2Files.push_back(fileID);
 		}

--- a/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Extractors/ClientDBExtractor.cpp
+++ b/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Extractors/ClientDBExtractor.cpp
@@ -62,11 +62,11 @@ void FixPathExtension(std::string& path)
 
 	if (StringUtils::EndsWith(path, ".mdx"))
 	{
-		path = path.substr(0, path.length() - 4) + ".complexmodel";
+		path = path.substr(0, path.length() - 4) + Model::FILE_EXTENSION;
 	}
 	else if (StringUtils::EndsWith(path, ".m2"))
 	{
-		path = path.substr(0, path.length() - 3) + ".complexmodel";
+		path = path.substr(0, path.length() - 3) + Model::FILE_EXTENSION;
 	}
 	else if (StringUtils::EndsWith(path, ".blp"))
 	{

--- a/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Extractors/ComplexModelExtractor.cpp
+++ b/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/Extractors/ComplexModelExtractor.cpp
@@ -3,6 +3,7 @@
 #include "AssetConverter/Casc/CascLoader.h"
 #include "AssetConverter/Util/ServiceLocator.h"
 
+#include <Base/Container/ConcurrentQueue.h>
 #include <Base/Util/DebugHandler.h>
 #include <Base/Util/StringUtils.h>
 
@@ -20,7 +21,7 @@ void ComplexModelExtractor::Process()
 	CascLoader* cascLoader = ServiceLocator::GetCascLoader();
 
 	const CascListFile& listFile = cascLoader->GetListFile();
-	const robin_hood::unordered_map<std::string, u32>& filePathToIDMap = listFile.GetFilePathToIDMap();
+	const std::vector<u32>& m2FileIDs = listFile.GetM2FileIDs();
 
 	struct FileListEntry
 	{
@@ -29,42 +30,50 @@ void ComplexModelExtractor::Process()
 		std::string path;
 	};
 
-	std::vector<FileListEntry> fileList = { };
-	fileList.reserve(filePathToIDMap.size());
+	u32 numFiles = static_cast<u32>(m2FileIDs.size());
+	moodycamel::ConcurrentQueue<FileListEntry> fileListQueue(numFiles);
 
-	for (auto& itr : filePathToIDMap)
+	enki::TaskSet processM2List(numFiles, [&runtime, &cascLoader, &fileListQueue, &m2FileIDs](enki::TaskSetPartition range, uint32_t threadNum)
 	{
-		if (!StringUtils::EndsWith(itr.first, ".m2"))
-			continue;
-
-		if (!cascLoader->FileExistsInCasc(itr.second))
-			continue;
-
-		std::string pathStr = itr.first;
-		std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(), ::tolower);
-
-		fs::path outputPath = (runtime->paths.complexModel / pathStr).replace_extension("complexmodel");
-		fs::create_directories(outputPath.parent_path());
-
-		FileListEntry& fileListEntry = fileList.emplace_back();
-		fileListEntry.fileID = itr.second;
-		fileListEntry.fileName = outputPath.filename().string();
-		fileListEntry.path = outputPath.string();
-	}
-
-	std::mutex printMutex;
-	u32 numFiles = static_cast<u32>(fileList.size());
-	u32 numProcessedFiles = 0;
-	u16 progressFlags = 0;
-	DebugHandler::Print("[ComplexModel Extractor] Processing {0} files", numFiles);
-
-	enki::TaskSet convertM2Task(numFiles, [&runtime, &cascLoader, &fileList, &numProcessedFiles, &progressFlags, &printMutex, numFiles](enki::TaskSetPartition range, uint32_t threadNum)
-	{
-		M2::Parser m2Parser = {};
 		for (u32 index = range.start; index < range.end; index++)
 		{
-			const FileListEntry& fileListEntry = fileList[index];
+			u32 m2FileID = m2FileIDs[index];
 
+			if (!cascLoader->FileExistsInCasc(m2FileID))
+				continue;
+
+			std::string pathStr = cascLoader->GetFilePathFromListFileID(m2FileID);
+			std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(), ::tolower);
+
+			fs::path outputPath = (runtime->paths.complexModel / pathStr).replace_extension(Model::FILE_EXTENSION);
+			fs::create_directories(outputPath.parent_path());
+
+			FileListEntry fileListEntry;
+			fileListEntry.fileID = m2FileID;
+			fileListEntry.fileName = outputPath.filename().string();
+			fileListEntry.path = outputPath.string();
+
+			fileListQueue.enqueue(fileListEntry);
+		}
+	});
+
+	runtime->scheduler.AddTaskSetToPipe(&processM2List);
+	runtime->scheduler.WaitforTask(&processM2List);
+
+	std::mutex printMutex;
+	u32 numProcessedFiles = 0;
+	u16 progressFlags = 0;
+
+	u32 numModelsToProcess = static_cast<u32>(fileListQueue.size_approx());
+	DebugHandler::Print("[ComplexModel Extractor] Processing {0} files", numModelsToProcess);
+
+	enki::TaskSet convertM2Task(numModelsToProcess, [&runtime, &cascLoader, &fileListQueue, &numProcessedFiles, &progressFlags, &printMutex, numModelsToProcess](enki::TaskSetPartition range, uint32_t threadNum)
+	{
+		M2::Parser m2Parser = {};
+
+		FileListEntry fileListEntry;
+		while(fileListQueue.try_dequeue(fileListEntry))
+		{
 			std::shared_ptr<Bytebuffer> rootBuffer = cascLoader->GetFileByID(fileListEntry.fileID);
 			if (!rootBuffer || rootBuffer->size == 0 || rootBuffer->writtenData == 0)
 				continue;
@@ -131,7 +140,7 @@ void ComplexModelExtractor::Process()
 				std::scoped_lock scopedLock(printMutex);
 				
 				f32 processedFiles = static_cast<f32>(++numProcessedFiles);
-				f32 progress = (processedFiles / static_cast<f32>(numFiles - 1)) * 10.0f;
+				f32 progress = (processedFiles / static_cast<f32>(numModelsToProcess - 1)) * 10.0f;
 				u32 bitToCheck = static_cast<u32>(progress);
 				u32 bitMask = 1 << bitToCheck;
 				

--- a/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/main.cpp
+++ b/Submodules/AssetConverter/Source/AssetConverter/AssetConverter/main.cpp
@@ -105,20 +105,20 @@ i32 main()
 
 			if (!JsonUtils::LoadFromPathOrCreate(runtime->json, fallbackJson, configPath))
 			{
-				DebugHandler::PrintFatal("[Runtime] Failed to Load {0} from {1}", CONFIG_NAME, absolutePath.c_str());
+				DebugHandler::PrintFatal("[AssetConverter] Failed to Load {0} from {1}", CONFIG_NAME, absolutePath.c_str());
 			}
 
 			std::string currentVersion = runtime->json["General"]["Version"];
 			if (currentVersion != CONFIG_VERSION)
 			{
-				DebugHandler::PrintFatal("[Runtime] Attempted to load outdated {0}. (Config Version : {1}, Expected Version : {2})", CONFIG_NAME.c_str(), currentVersion.c_str(), CONFIG_VERSION.c_str());
+				DebugHandler::PrintFatal("[AssetConverter] Attempted to load outdated {0}. (Config Version : {1}, Expected Version : {2})", CONFIG_NAME.c_str(), currentVersion.c_str(), CONFIG_VERSION.c_str());
 			}
 
 			runtime->isInDebugMode = runtime->json["General"]["DebugMode"];
 
 			if (!configExists)
 			{
-				DebugHandler::Print("[Runtime] This appears to be the first time you are running the asset converter. A config file have been created named 'AssetConverterConfig.json'.\nYou may want to go through the configuration file and set it up before running.\n\nPress any key if you wish to continue.");
+				DebugHandler::Print("[AssetConverter] This appears to be the first time you are running the asset converter. A config file have been created named 'AssetConverterConfig.json'.\nYou may want to go through the configuration file and set it up before running.\n\nPress any key if you wish to continue.");
 				std::cin.get();
 			}
 		}


### PR DESCRIPTION
Added .mdx extension check for CascListFile Loading
Replaced all instances of hardcoded extensions for Map and Model Files with extensions found in the FileFormat Library Updated M2 extraction to use m2/mdx specific fileIDs parsed by CascListFile instead of parsing the entire list file. Updated Submodule Engine