### PR TITLE
Fix Linux build: premake link settings, Build/ gitignore, Engine bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@ Source/Meta/MetaGen/
 Source/Meta/MetaGen.staging/
 Source/Meta/MetaGen.previous/
 
-build*/ 
+build*/
+Build*/
 .vs/
 .vscode/
 out/

--- a/Premake/ProjectUtil.lua
+++ b/Premake/ProjectUtil.lua
@@ -44,8 +44,8 @@ end
 
 systemToExecutableExtensionMap =
 {
-    windows = "exe",
-    linux = "sh"
+    windows = ".exe",
+    linux = ""
 }
 
 systemToDynamicLibExtensionMap =
@@ -236,6 +236,11 @@ Solution.Util.CreateProject = function(name, projectType, binDir, dependencies, 
 
         characterset ("ASCII")
         editandcontinue "Off"
+
+        filter "system:linux"
+            linkgroups "On"
+            linkoptions { "-Wl,-rpath,'$$ORIGIN'" }
+        filter {}
 
         filter "configurations:Debug"
             runtime "Debug"


### PR DESCRIPTION
- Premake/ProjectUtil.lua: enable linkgroups on Linux (GNU ld resolves static libs left-to-right), add $ORIGIN rpath so executables find bundled shared libs, fix executable extension map (no extension on Linux, was "sh")
- .gitignore: also ignore Build*/ - the lowercase build*/ pattern only matched the generated Build/ dir on case-insensitive filesystems
- Submodules/Engine: bump to LinuxBuildFix (Linux/clang build and runtime fixes)